### PR TITLE
optimize: eliminate redundant testing after PR merge

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,8 @@ concurrency:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    # Only run tests on pull requests, skip on pushes to main
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -38,10 +40,9 @@ jobs:
 
   deploy-docs:
     name: Deploy Documentation
-    runs-on: ubuntu-latest
-    needs: test
-    # Only deploy on push to main (not on PRs) OR manual trigger
+    # Only run deployment on pushes to main (after merge) or manual trigger
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
- Only run tests on pull requests, skip on pushes to main
- Remove test job dependency from deploy-docs job
- Maintain manual trigger capability for both jobs
- Speeds up documentation deployment by eliminating ~15s redundant testing
- Maintains security with tests still required on all PRs

Following project conventions:
- Branch-based development workflow
- Tests run before merge via PR
- Documentation deploys immediately after merge
- Manual triggers preserved for troubleshooting