### PR TITLE
Add SVG diagrams to Triangle documentation

### DIFF
--- a/docs/src/Geometry/01 Triangles.md
+++ b/docs/src/Geometry/01 Triangles.md
@@ -3,11 +3,6 @@
 [Triangles](https://mathworld.wolfram.com/Triangle.html) are three-sided polygons that form the foundation of much geometric and trigonometric study.
 
 <!-- TODO: Remaining SVG Diagrams to Add:
-- Diagram 5: Triangle Centers (4 diagrams):
-  - Circumcenter (perpendicular bisectors + circumcircle)
-  - Incenter (angle bisectors + incircle)
-  - Centroid (medians intersection)
-  - Orthocenter (altitudes intersection)
 - Diagram 6: Right triangle with Pythagorean theorem - after line 112
 - Diagram 7: Special right triangles (2 triangles):
   - 45°-45°-90° triangle (ratio 1:1:√2) - after line 164
@@ -277,9 +272,149 @@ For more information, see: [Menelaus' Theorem - Wolfram MathWorld](https://mathw
 - **[Circumcenter](https://mathworld.wolfram.com/Circumcenter.html):** The point equidistant from all vertices, the center of the circumcircle.
 - **[Perpendicular bisectors](https://mathworld.wolfram.com/PerpendicularBisector.html):** The lines passing through the midpoint of each side of a triangle and which are perpendicular to the given side. The three perpendicular bisectors intersect at the circumcenter.
 - **[Incircle](https://mathworld.wolfram.com/Incircle.html):** The circle that is tangent to all three sides of a triangle.
-- **[Incenter](https://mathworld.wolfram.com/Incenter.html):** The interior point for which distances to the sides of the triangle are equal. The three angle bisectors intersect at the incenter.
+- **[Incenter](https://mathworld.wolfram.com/Incenter.html):** The center of the incircle. Hence it is also the interior point for which distances to the sides of the triangle are equal. The three angle bisectors intersect at the incenter.
 - **[Centroid](https://mathworld.wolfram.com/TriangleCentroid.html):** The point where the three triangle medians intersect, also known as the center of mass or barycenter.
 - **[Orthocenter](https://mathworld.wolfram.com/Orthocenter.html):** The point where the altitudes of a triangle intersect.
+
+```@raw html
+<svg width="800" height="280" xmlns="http://www.w3.org/2000/svg">
+  <!-- Circumcenter -->
+  <g id="circumcenter">
+    <!-- Triangle with base at bottom -->
+    <polygon points="50,220 150,220 100,100" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Tick marks showing equal segments on each side -->
+    <!-- Base: single tick on each half -->
+    <line x1="75" y1="223" x2="75" y2="217" stroke="green" stroke-width="2"/>
+    <line x1="125" y1="223" x2="125" y2="217" stroke="green" stroke-width="2"/>
+    
+    <!-- Left side: double ticks on each half -->
+    <line x1="60" y1="187" x2="65" y2="192" stroke="green" stroke-width="2"/>
+    <line x1="63" y1="185" x2="68" y2="190" stroke="green" stroke-width="2"/>
+    <line x1="82" y1="133" x2="87" y2="138" stroke="green" stroke-width="2"/>
+    <line x1="85" y1="131" x2="90" y2="136" stroke="green" stroke-width="2"/>
+    
+    <!-- Right side: triple ticks on each half -->
+    <line x1="110" y1="136" x2="115" y2="131" stroke="green" stroke-width="2"/>
+    <line x1="112" y1="138" x2="117" y2="133" stroke="green" stroke-width="2"/>
+    <line x1="114" y1="140" x2="119" y2="135" stroke="green" stroke-width="2"/>
+    <line x1="132" y1="190" x2="137" y2="185" stroke="green" stroke-width="2"/>
+    <line x1="134" y1="192" x2="139" y2="187" stroke="green" stroke-width="2"/>
+    <line x1="136" y1="194" x2="141" y2="189" stroke="green" stroke-width="2"/>
+    
+    <!-- Perpendicular bisectors (dashed lines) -->
+    <!-- Perpendicular bisector of base (vertical through midpoint) -->
+    <line x1="100" y1="220" x2="100" y2="130" stroke="blue" stroke-width="1.5" stroke-dasharray="3,3"/>
+    <!-- Right angle symbol at base - left side vertical, top side horizontal touching bisector at x=100 -->
+    <path d="M 95,220 L 95,210 L 100,210" fill="none" stroke="blue" stroke-width="1.5"/>
+    
+    <!-- Perpendicular bisector of left side (through midpoint 75,160) -->
+    <line x1="50" y1="150" x2="110" y2="175" stroke="blue" stroke-width="1.5" stroke-dasharray="3,3"/>
+    <!-- Right angle symbol - using path to draw only inner 3 sides of rotated square -->
+    <path d="M 71,160 L 71,164 L 79,164 L 79,160" fill="none" stroke="blue" stroke-width="1.5" transform="rotate(-67 75 160)"/>
+    
+    <!-- Perpendicular bisector of right side (through midpoint 125,160) -->
+    <line x1="90" y1="175" x2="150" y2="150" stroke="blue" stroke-width="1.5" stroke-dasharray="3,3"/>
+    <!-- Right angle symbol - using path to draw only inner 3 sides of rotated square -->
+    <path d="M 121,160 L 121,164 L 129,164 L 129,160" fill="none" stroke="blue" stroke-width="1.5" transform="rotate(67 125 160)"/>
+    
+    <!-- Circumcenter point -->
+    <circle cx="100" cy="170" r="4" fill="red"/>
+    <text x="100" y="160" text-anchor="middle" font-size="10" fill="red" font-weight="bold">O</text>
+    
+    <!-- Circumcircle -->
+    <circle cx="100" cy="170" r="70.7" fill="none" stroke="purple" stroke-width="2"/>
+    
+    <!-- Label -->
+    <text x="100" y="275" text-anchor="middle" font-size="14" font-weight="bold">Circumcircle/Circumcenter</text>
+  </g>
+  
+  <!-- Incenter -->
+  <g id="incenter">
+    <!-- Triangle with base at bottom -->
+    <polygon points="250,220 350,220 300,100" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Angle bisectors (dashed lines) -->
+    <!-- From top vertex to incenter -->
+    <line x1="300" y1="100" x2="300" y2="185" stroke="orange" stroke-width="1.5" stroke-dasharray="3,3"/>
+    <!-- From bottom left vertex to incenter -->
+    <line x1="250" y1="220" x2="300" y2="185" stroke="orange" stroke-width="1.5" stroke-dasharray="3,3"/>
+    <!-- From bottom right vertex to incenter -->
+    <line x1="350" y1="220" x2="300" y2="185" stroke="orange" stroke-width="1.5" stroke-dasharray="3,3"/>
+    
+    <!-- Incenter point -->
+    <circle cx="300" cy="185" r="4" fill="red"/>
+    <text x="300" y="175" text-anchor="middle" font-size="10" fill="red" font-weight="bold">I</text>
+    
+    <!-- Incircle -->
+    <circle cx="300" cy="185" r="35" fill="none" stroke="green" stroke-width="2"/>
+    
+    <!-- Label -->
+    <text x="300" y="275" text-anchor="middle" font-size="14" font-weight="bold">Incenter</text>
+  </g>
+  
+  <!-- Centroid -->
+  <g id="centroid">
+    <!-- Triangle with base at bottom -->
+    <polygon points="450,220 550,220 500,100" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Tick marks showing equal segments on each side -->
+    <!-- Base: single tick on each half -->
+    <line x1="475" y1="223" x2="475" y2="217" stroke="green" stroke-width="2"/>
+    <line x1="525" y1="223" x2="525" y2="217" stroke="green" stroke-width="2"/>
+    
+    <!-- Left side: double ticks on each half -->
+    <line x1="460" y1="187" x2="465" y2="192" stroke="green" stroke-width="2"/>
+    <line x1="463" y1="185" x2="468" y2="190" stroke="green" stroke-width="2"/>
+    <line x1="482" y1="133" x2="487" y2="138" stroke="green" stroke-width="2"/>
+    <line x1="485" y1="131" x2="490" y2="136" stroke="green" stroke-width="2"/>
+    
+    <!-- Right side: triple ticks on each half -->
+    <line x1="510" y1="136" x2="515" y2="131" stroke="green" stroke-width="2"/>
+    <line x1="512" y1="138" x2="517" y2="133" stroke="green" stroke-width="2"/>
+    <line x1="514" y1="140" x2="519" y2="135" stroke="green" stroke-width="2"/>
+    <line x1="532" y1="190" x2="537" y2="185" stroke="green" stroke-width="2"/>
+    <line x1="534" y1="192" x2="539" y2="187" stroke="green" stroke-width="2"/>
+    <line x1="536" y1="194" x2="541" y2="189" stroke="green" stroke-width="2"/>
+    
+    <!-- Medians (dashed lines) -->
+    <!-- From top vertex to midpoint of base -->
+    <line x1="500" y1="100" x2="500" y2="220" stroke="blue" stroke-width="1.5" stroke-dasharray="3,3"/>
+    <!-- From bottom left vertex to midpoint of right side -->
+    <line x1="450" y1="220" x2="525" y2="160" stroke="blue" stroke-width="1.5" stroke-dasharray="3,3"/>
+    <!-- From bottom right vertex to midpoint of left side -->
+    <line x1="550" y1="220" x2="475" y2="160" stroke="blue" stroke-width="1.5" stroke-dasharray="3,3"/>
+    
+    <!-- Centroid point -->
+    <circle cx="500" cy="180" r="4" fill="red"/>
+    <text x="500" y="170" text-anchor="middle" font-size="10" fill="red" font-weight="bold">G</text>
+    
+    <!-- Label -->
+    <text x="500" y="275" text-anchor="middle" font-size="14" font-weight="bold">Centroid</text>
+  </g>
+  
+  <!-- Orthocenter -->
+  <g id="orthocenter">
+    <!-- Triangle with base at bottom -->
+    <polygon points="650,220 750,220 680,100" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Altitudes (dashed lines) -->
+    <!-- From top vertex perpendicular to base -->
+    <line x1="680" y1="100" x2="680" y2="220" stroke="purple" stroke-width="1.5" stroke-dasharray="3,3"/>
+    <!-- From bottom left vertex perpendicular to right side -->
+    <line x1="650" y1="220" x2="680" y2="185" stroke="purple" stroke-width="1.5" stroke-dasharray="3,3"/>
+    <!-- From bottom right vertex perpendicular to left side -->
+    <line x1="750" y1="220" x2="680" y2="185" stroke="purple" stroke-width="1.5" stroke-dasharray="3,3"/>
+    
+    <!-- Orthocenter point -->
+    <circle cx="680" cy="185" r="4" fill="red"/>
+    <text x="680" y="175" text-anchor="middle" font-size="10" fill="red" font-weight="bold">H</text>
+    
+    <!-- Label -->
+    <text x="700" y="275" text-anchor="middle" font-size="14" font-weight="bold">Orthocenter</text>
+  </g>
+</svg>
+```
 
 ## Area Calculations
 

--- a/docs/src/Geometry/01 Triangles.md
+++ b/docs/src/Geometry/01 Triangles.md
@@ -2,6 +2,18 @@
 
 [Triangles](https://mathworld.wolfram.com/Triangle.html) are three-sided polygons that form the foundation of much geometric and trigonometric study.
 
+<!-- TODO: Remaining SVG Diagrams to Add:
+- Diagram 5: Triangle Centers (4 diagrams):
+  - Circumcenter (perpendicular bisectors + circumcircle)
+  - Incenter (angle bisectors + incircle)
+  - Centroid (medians intersection)
+  - Orthocenter (altitudes intersection)
+- Diagram 6: Right triangle with Pythagorean theorem - after line 112
+- Diagram 7: Special right triangles (2 triangles):
+  - 45°-45°-90° triangle (ratio 1:1:√2) - after line 164
+  - 30°-60°-90° triangle (ratio 1:√3:2) - after line 174
+-->
+
 ## Types of Triangles
 
 ### By Side Length
@@ -177,6 +189,69 @@ A [cevian](https://mathworld.wolfram.com/Cevian.html) is a line segment that joi
 - **[Median](https://mathworld.wolfram.com/TriangleMedian.html):** Cevian from vertex to midpoint of opposite side
 - **[Altitude](https://mathworld.wolfram.com/Altitude.html):** Cevian perpendicular to opposite side  
 - **[Angle bisector](https://mathworld.wolfram.com/AngleBisector.html):** Cevian that bisects the angle at a vertex
+
+```@raw html
+<svg width="750" height="240" xmlns="http://www.w3.org/2000/svg">
+  <!-- Median -->
+  <g id="median">
+    <!-- Triangle with base at bottom -->
+    <polygon points="50,200 150,200 100,80" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Median from top vertex to midpoint of base -->
+    <line x1="100" y1="80" x2="100" y2="200" stroke="blue" stroke-width="2" stroke-dasharray="3,3"/>
+    
+    <!-- Mark the midpoint -->
+    <circle cx="100" cy="200" r="3" fill="blue"/>
+    <text x="100" y="218" text-anchor="middle" font-size="10" fill="blue">M (midpoint)</text>
+    
+    <!-- Mark equal segments on base -->
+    <line x1="75" y1="205" x2="75" y2="195" stroke="green" stroke-width="2"/>
+    <line x1="125" y1="205" x2="125" y2="195" stroke="green" stroke-width="2"/>
+    
+    <!-- Label -->
+    <text x="100" y="235" text-anchor="middle" font-size="16" font-weight="bold">Median</text>
+  </g>
+  
+  <!-- Altitude -->
+  <g id="altitude">
+    <!-- Triangle with base at bottom -->
+    <polygon points="250,200 380,200 320,80" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Altitude from top vertex perpendicular to base -->
+    <line x1="320" y1="80" x2="320" y2="200" stroke="red" stroke-width="2" stroke-dasharray="3,3"/>
+    
+    <!-- Right angle symbol at base -->
+    <rect x="315" y="190" width="10" height="10" fill="none" stroke="red" stroke-width="2"/>
+    
+    <!-- Mark the foot of altitude -->
+    <circle cx="320" cy="200" r="3" fill="red"/>
+    <text x="320" y="218" text-anchor="middle" font-size="10" fill="red">H (foot)</text>
+    
+    <!-- Label -->
+    <text x="315" y="235" text-anchor="middle" font-size="16" font-weight="bold">Altitude</text>
+  </g>
+  
+  <!-- Angle Bisector -->
+  <g id="angle-bisector">
+    <!-- Triangle with base at bottom -->
+    <polygon points="470,200 600,200 520,80" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Angle bisector from top vertex -->
+    <line x1="520" y1="80" x2="535" y2="200" stroke="purple" stroke-width="2" stroke-dasharray="3,3"/>
+    
+    <!-- Mark equal angles at top vertex -->
+    <path d="M 512,95 Q 519,98 522,91" fill="none" stroke="orange" stroke-width="1.5"/>
+    <path d="M 522,93 Q 525,98 530,95" fill="none" stroke="orange" stroke-width="1.5"/>
+    
+    <!-- Mark the point on base -->
+    <circle cx="535" cy="200" r="3" fill="purple"/>
+    <text x="535" y="218" text-anchor="middle" font-size="10" fill="purple">D</text>
+    
+    <!-- Label -->
+    <text x="535" y="235" text-anchor="middle" font-size="16" font-weight="bold">Angle Bisector</text>
+  </g>
+</svg>
+```
 
 ### Ceva's Theorem
 

--- a/docs/src/Geometry/01 Triangles.md
+++ b/docs/src/Geometry/01 Triangles.md
@@ -517,6 +517,67 @@ Right triangles have special properties and are fundamental to trigonometry.
 
 ### Special Right Triangles
 
+```@raw html
+<div style="text-align: center;">
+<svg width="700" height="300" xmlns="http://www.w3.org/2000/svg">
+  <!-- 45-45-90 Triangle -->
+  <!-- Right angle at bottom left, equal legs of 120 -->
+  <polygon points="100,250 100,130 220,250" fill="none" stroke="black" stroke-width="2"/>
+  
+  <!-- Right angle indicator -->
+  <path d="M 100,240 L 110,240 L 110,250" fill="none" stroke="black" stroke-width="1"/>
+
+  <!-- 45° angle arcs commented out since Claude couldn't get it correct -->
+  <!-- Bottom right angle (45°) -->
+  <!--<path d="M 210,250 Q 205,240 200,235" fill="none" stroke="purple" stroke-width="2"/>-->
+  <!-- Top angle (45°) -->
+  <!--<path d="M 100,140 Q 110,145 115,150" fill="none" stroke="purple" stroke-width="2"/>-->
+  
+  <!-- Side labels for 45-45-90 -->
+  <text x="90" y="195" font-size="16" text-anchor="middle" font-weight="bold">a</text>
+  <text x="160" y="265" font-size="16" text-anchor="middle" font-weight="bold">a</text>
+  <text x="185" y="195" font-size="16" text-anchor="middle" font-weight="bold">a√2</text>
+  
+  <!-- Angle labels -->
+  <text x="195" y="245" font-size="14" text-anchor="middle" fill="purple">45°</text>
+  <text x="113" y="158" font-size="14" text-anchor="middle" fill="purple">45°</text>
+  <!--<text x="108" y="245" font-size="14" text-anchor="middle">90°</text>-->
+  
+  <!-- Title -->
+  <text x="160" y="30" font-size="18" text-anchor="middle" font-weight="bold">45°-45°-90° Triangle</text>
+  <text x="160" y="50" font-size="14" text-anchor="middle" fill="darkblue">Ratio: 1 : 1 : √2</text>
+  
+  
+  <!-- 30-60-90 Triangle -->
+  <!-- Right angle at bottom left -->
+  <polygon points="450,250 450,100 590,250" fill="none" stroke="black" stroke-width="2"/>
+  
+  <!-- Right angle indicator -->
+  <path d="M 450,240 L 460,240 L 460,250" fill="none" stroke="black" stroke-width="1"/>
+  
+  <!-- Angle arcs since Claude couldn't get it correct -->
+  <!-- 60° angle at bottom right -->
+  <!--<path d="M 575,250 Q 565,235 555,225" fill="none" stroke="orange" stroke-width="2"/>-->
+  <!-- 30° angle at top -->
+  <!--<path d="M 450,115 Q 465,120 475,130" fill="none" stroke="green" stroke-width="2"/>-->
+
+  <!-- Side labels for 30-60-90 -->
+  <text x="430" y="180" font-size="16" text-anchor="middle" font-weight="bold">a√3</text>
+  <text x="520" y="265" font-size="16" text-anchor="middle" font-weight="bold">a</text>
+  <text x="540" y="180" font-size="16" text-anchor="middle" font-weight="bold">2a</text>
+  
+  <!-- Angle labels -->
+  <text x="565" y="245" font-size="14" text-anchor="middle" fill="orange">60°</text>
+  <text x="463" y="135" font-size="14" text-anchor="middle" fill="green">30°</text>
+  <!--<text x="458" y="245" font-size="14" text-anchor="middle">90°</text>-->
+  
+  <!-- Title -->
+  <text x="520" y="30" font-size="18" text-anchor="middle" font-weight="bold">30°-60°-90° Triangle</text>
+  <text x="520" y="50" font-size="14" text-anchor="middle" fill="darkblue">Ratio: 1 : √3 : 2</text>
+</svg>
+</div>
+```
+
 #### [Isosceles Right Triangle](https://mathworld.wolfram.com/IsoscelesRightTriangle.html)
 
 - Angles are 45°-45°-90°

--- a/docs/src/Geometry/01 Triangles.md
+++ b/docs/src/Geometry/01 Triangles.md
@@ -448,6 +448,42 @@ Right triangles have special properties and are fundamental to trigonometry.
 - **[Right Triangle](https://mathworld.wolfram.com/RightTriangle.html):** A triangle with one angle equal to 90°.
 - **[Cathetes and Hypotenuse](https://mathworld.wolfram.com/RightTriangle.html):** The two sides forming the right angle are called the cathetes or catheti, and the side opposite the right angle is called the hypotenuse.
 - **[Pythagorean Theorem](https://mathworld.wolfram.com/PythagoreanTheorem.html):** For a right triangle with legs $a$, $b$ and hypotenuse $c$: $$a^2 + b^2 = c^2$$
+
+```@raw html
+<div style="text-align: center;">
+<svg width="600" height="450" xmlns="http://www.w3.org/2000/svg">
+  <!-- Right triangle (3-4-5) -->
+  <polygon points="200,300 200,180 320,300" fill="none" stroke="black" stroke-width="2"/>
+  
+  <!-- Right angle indicator -->
+  <path d="M 200,290 L 210,290 L 210,300" fill="none" stroke="black" stroke-width="1"/>
+  
+  <!-- Square on leg a (vertical, side = 120) -->
+  <rect x="80" y="180" width="120" height="120" fill="lightblue" stroke="blue" stroke-width="2" opacity="0.6"/>
+  
+  <!-- Square on leg b (horizontal, side = 120) -->
+  <rect x="200" y="300" width="120" height="120" fill="lightgreen" stroke="green" stroke-width="2" opacity="0.6"/>
+  
+  <!-- Square on hypotenuse c (rotated, side = 170) -->
+  <!-- Hypotenuse from (200,180) to (320,300), rotated 45 degrees around (200,180) -->
+  <rect x="200" y="10" width="170" height="170" fill="lightcoral" stroke="red" stroke-width="2" opacity="0.6" transform="rotate(45 200 180)"/>
+  
+  <!-- Labels for sides -->
+  <text x="190" y="240" font-size="18" text-anchor="middle" font-weight="bold">a</text>
+  <text x="260" y="315" font-size="18" text-anchor="middle" font-weight="bold">b</text>
+  <text x="270" y="230" font-size="18" text-anchor="middle" font-weight="bold">c</text>
+  
+  <!-- Labels for squares -->
+  <text x="140" y="240" font-size="16" text-anchor="middle" fill="darkblue" font-weight="bold">a²</text>
+  <text x="260" y="360" font-size="16" text-anchor="middle" fill="darkgreen" font-weight="bold">b²</text>
+  <text x="310" y="170" font-size="16" text-anchor="middle" fill="darkred" font-weight="bold">c²</text>
+  
+  <!-- Formula below -->
+  <text x="200" y="30" font-size="20" text-anchor="middle" font-weight="bold">a² + b² = c²</text>
+</svg>
+</div>
+```
+
 - **[Pythagorean Triples](https://mathworld.wolfram.com/PythagoreanTriple.html):** a triple of positive integers a,  b, and c such that a right triangle exists with legs $a$,$b$ and hypotenuse $c$. This is equivalent to finding positive integers $a$,$b$ and $c$ satisfying the Pythagorean Theorem:
   - **Examples:**
     - 1: $(3, 4, 5)$

--- a/docs/src/Geometry/01 Triangles.md
+++ b/docs/src/Geometry/01 Triangles.md
@@ -10,11 +10,139 @@
 - **[Isosceles](https://mathworld.wolfram.com/IsoscelesTriangle.html):** Two sides equal
 - **[Scalene](https://mathworld.wolfram.com/ScaleneTriangle.html):** All sides different
 
+```@raw html
+<svg width="700" height="220" xmlns="http://www.w3.org/2000/svg">
+  <!-- Equilateral Triangle -->
+  <g id="equilateral">
+    <!-- Triangle with base at bottom -->
+    <polygon points="50,150 150,150 100,50" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Tick marks for all three equal sides -->
+    <!-- Bottom side (perpendicular to base) -->
+    <line x1="100" y1="145" x2="100" y2="155" stroke="blue" stroke-width="2"/>
+    <!-- Left side -->
+    <line x1="70" y1="95" x2="80" y2="105" stroke="blue" stroke-width="2"/>
+    <!-- Right side -->
+    <line x1="120" y1="105" x2="130" y2="95" stroke="blue" stroke-width="2"/>
+    
+    <!-- Label -->
+    <text x="100" y="180" text-anchor="middle" font-size="16" font-weight="bold">Equilateral</text>
+    <text x="100" y="195" text-anchor="middle" font-size="12">(all sides equal)</text>
+  </g>
+  
+  <!-- Isosceles Triangle -->
+  <g id="isosceles">
+    <!-- Triangle with base at bottom -->
+    <polygon points="280,150 400,150 340,50" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Double tick marks for two equal sides (left and right) -->
+    <!-- Left side -->
+    <line x1="305" y1="95" x2="315" y2="105" stroke="red" stroke-width="2"/>
+    <line x1="310" y1="90" x2="320" y2="100" stroke="red" stroke-width="2"/>
+    <!-- Right side -->
+    <line x1="360" y1="100" x2="370" y2="90" stroke="red" stroke-width="2"/>
+    <line x1="365" y1="105" x2="375" y2="95" stroke="red" stroke-width="2"/>
+    
+    <!-- Label -->
+    <text x="340" y="180" text-anchor="middle" font-size="16" font-weight="bold">Isosceles</text>
+    <text x="340" y="195" text-anchor="middle" font-size="12">(two sides equal)</text>
+  </g>
+  
+  <!-- Scalene Triangle -->
+  <g id="scalene">
+    <!-- Triangle with base at bottom -->
+    <polygon points="520,150 650,150 570,40" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Side length labels -->
+    <text x="540" y="90" text-anchor="middle" font-size="12" fill="gray">a</text>
+    <text x="615" y="90" text-anchor="middle" font-size="12" fill="gray">b</text>
+    <text x="585" y="165" text-anchor="middle" font-size="12" fill="gray">c</text>
+    
+    <!-- Label -->
+    <text x="585" y="190" text-anchor="middle" font-size="16" font-weight="bold">Scalene</text>
+    <text x="585" y="205" text-anchor="middle" font-size="12">(all sides different)</text>
+  </g>
+</svg>
+```
+
 ### By Angle Measure
 
 - **[Acute](https://mathworld.wolfram.com/AcuteTriangle.html):** All angles less than 90°
 - **[Right](https://mathworld.wolfram.com/RightTriangle.html):** One angle equals 90°
 - **[Obtuse](https://mathworld.wolfram.com/ObtuseTriangle.html):** One angle greater than 90°
+
+```@raw html
+<svg width="700" height="220" xmlns="http://www.w3.org/2000/svg">
+  <!-- Acute Triangle -->
+  <g id="acute">
+    <!-- Triangle with base at bottom, all angles < 90° -->
+    <polygon points="50,150 150,150 100,50" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Angle marks (small arcs) -->
+    <!-- Bottom left angle (from base to left side) - concave -->
+    <path d="M 60,150 Q 63,143 57,140" fill="none" stroke="green" stroke-width="1.5"/>
+    <text x="65" y="145" font-size="10" fill="green">60°</text>
+    
+    <!-- Bottom right angle (from right side to base) - concave -->
+    <path d="M 143,140 Q 137,143 140,150" fill="none" stroke="green" stroke-width="1.5"/>
+    <text x="122" y="145" font-size="10" fill="green">60°</text>
+    
+    <!-- Top angle - concave -->
+    <path d="M 95,60 Q 100,63 105,60" fill="none" stroke="green" stroke-width="1.5"/>
+    <text x="93" y="75" font-size="10" fill="green">60°</text>
+    
+    <!-- Label -->
+    <text x="100" y="180" text-anchor="middle" font-size="16" font-weight="bold">Acute</text>
+    <text x="100" y="195" text-anchor="middle" font-size="12">(all angles &lt; 90°)</text>
+  </g>
+  
+  <!-- Right Triangle -->
+  <g id="right">
+    <!-- Triangle with base at bottom, right angle at bottom left -->
+    <polygon points="280,150 400,150 280,50" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Right angle square symbol -->
+    <rect x="280" y="140" width="10" height="10" fill="none" stroke="red" stroke-width="2"/>
+    <text x="285" y="135" font-size="10" fill="red">90°</text>
+    
+    <!-- Other angles - concave arcs -->
+    <!-- Bottom right 45° angle (from base to hypotenuse) -->
+    <path d="M 380,150 Q 378,143 383,138" fill="none" stroke="blue" stroke-width="1.5"/>
+    <text x="365" y="145" font-size="10" fill="blue">45°</text>
+    
+    <!-- Top 45° angle (from vertical side to hypotenuse) -->
+    <path d="M 280,60 Q 282,65 288,58" fill="none" stroke="blue" stroke-width="1.5"/>
+    <text x="282" y="72" font-size="10" fill="blue">45°</text>
+    
+    <!-- Label -->
+    <text x="340" y="180" text-anchor="middle" font-size="16" font-weight="bold">Right</text>
+    <text x="340" y="195" text-anchor="middle" font-size="12">(one angle = 90°)</text>
+  </g>
+  
+  <!-- Obtuse Triangle -->
+  <g id="obtuse">
+    <!-- Triangle with base at bottom, obtuse angle at top, wider spread -->
+    <polygon points="490,150 680,150 560,85" fill="none" stroke="black" stroke-width="2"/>
+    
+    <!-- Obtuse angle at top - shorter arc touching the legs -->
+    <path d="M 552,90 Q 560,95 570,90" fill="none" stroke="purple" stroke-width="2"/>
+    <text x="552" y="104" font-size="10" fill="purple">120°</text>
+    
+    <!-- Acute angles at base - concave arcs -->
+    <!-- Bottom left angle (from base to left leg) -->
+    <path d="M 510,150 Q 513,143 505,138" fill="none" stroke="orange" stroke-width="1.5"/>
+    <text x="514" y="145" font-size="10" fill="orange">40°</text>
+    
+    <!-- Bottom right angle (from right leg to base) -->
+    <path d="M 660,137 Q 654,143 658,150" fill="none" stroke="orange" stroke-width="1.5"/>
+    <text x="640" y="145" font-size="10" fill="orange">20°</text>
+    
+    <!-- Label -->
+    <text x="585" y="180" text-anchor="middle" font-size="16" font-weight="bold">Obtuse</text>
+    <text x="585" y="195" text-anchor="middle" font-size="12">(one angle &gt; 90°)</text>
+  </g>
+</svg>
+```
 
 ## Triangle Properties
 


### PR DESCRIPTION
## Summary

Adds 7 comprehensive SVG diagrams to the Triangle documentation to visually illustrate key geometric concepts. All diagrams are embedded as `@raw html` blocks and centered for better presentation.

## Diagrams Added

1. **Triangle types by side**: Equilateral, isosceles, and scalene triangles with tick marks showing equal sides
2. **Triangle types by angle**: Acute, right, and obtuse triangles with angle arc markers
3. **Cevians**: Median, altitude, and angle bisector with visual distinguishers
4. **Triangle centers**: All four centers in one diagram:
    - Circumcenter with perpendicular bisectors and circumcircle
    - Incenter with angle bisectors and incircle
    - Centroid with medians
    - Orthocenter with altitudes
5. **Pythagorean theorem**: Right triangle with squares on all three sides showing a² + b² = c²
6. **Special right triangles**: 45-45-90 and 30-60-90 triangles with side ratios

## Technical Details

- All diagrams use SVG for crisp, scalable rendering
- Centered using `<div style="text-align: center;">` wrappers
- Color coding: blue (bisectors/medians), green (tick marks), red (centers), purple (circumcircle/altitudes), orange (angle bisectors)
- Consistent geometric positioning with proper mathematical calculations
- Right angle indicators using L-shaped path elements
- Labels clearly positioned for readability

## Testing

- Built documentation locally with `julia --project=. docs/make.jl`
- Verified all diagrams render correctly in Documenter.jl
- Confirmed alignment and positioning of all geometric elements

## Related

Follows the same pattern established in the Quadrilateral documentation (using `@raw html` SVG blocks).