### PR TITLE
Phase 4: Update instructions for workspace layout and notebook environment

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,27 +14,63 @@
 - **`docs/`**: Documenter.jl deploying to `https://study.fourm.info/math_foundations/` (cross-repo to `math_tech_study`)
 - **`notebooks/`**: Jupyter notebooks for exploration (not tested in CI)
 
+## Julia Workspace Layout
+
+This repository uses a Julia workspace. The root `Project.toml` has a `[workspace]` table listing
+member environments. Each member has its own `Project.toml` and `Manifest.toml`:
+
+| Path | Purpose |
+|---|---|
+| `Project.toml` | Root package — defines `Math_Foundations` as a library |
+| `test/Project.toml` | Test-only deps (`Test`, etc.) — workspace member |
+| `docs/Project.toml` | Docs deps (`Documenter`) — workspace member; uses `Pkg.develop(path=".")` |
+| `notebooks/Project.toml` | Notebook superset (Makie stack + root deps) — **not** a workspace member |
+
+The `notebooks/` environment is intentionally excluded from the workspace `projects` list because
+it is a developer-only interactive environment, not a dependency of any other member.
+
+All `Manifest.toml` files are gitignored. They are regenerated locally by `Pkg.instantiate()`.
+
+### Adding a New Workspace Member
+
+If you add a new subdirectory environment (e.g. `scripts/`):
+1. Create `scripts/Project.toml` with a `name`, `uuid` (generated via `uuidgen`), and `[deps]`
+2. Add `"scripts"` to the `projects` list in the root `Project.toml` `[workspace]` table
+3. Never hard-code UUIDs — always generate them with `uuidgen` on the command line
+
+### Project.toml Header Convention
+
+Every named `Project.toml` (root and workspace members that are packages) must have:
+
+```toml
+name = "PackageName"
+uuid = "<output of uuidgen>"
+version = "0.1.0"
+```
+
+Non-package member environments (like `test/` and `docs/`) do not need `name`/`uuid`.
+
 ## Key Workflows
 
 ### Local Development
 
 ```bash
-# Run tests
-julia --project=. test/runtests.jl
+# Run tests (uses test/ workspace member environment)
+julia --project=. -e 'using Pkg; Pkg.test()'
 
 # CI mode (headless plotting)
-CI=true julia --project=. test/runtests.jl
+CI=true julia --project=. -e 'using Pkg; Pkg.test()'
 
-# Build documentation
-julia --project=. docs/make.jl
+# Build documentation (uses docs/ workspace member environment)
+julia --project=docs docs/make.jl
 ```
 
-**IMPORTANT**: Always run `julia --project=. docs/make.jl` after making changes to documentation files in `docs/src/`. This allows the user to preview changes in the browser immediately without running the build manually.
+**IMPORTANT**: Always run `julia --project=docs docs/make.jl` after making changes to documentation files in `docs/src/`. This allows the user to preview changes in the browser immediately without running the build manually.
 
 ## Julia Compilation Considerations
 - **Be Patient with First Runs**: Julia often needs to precompile packages and rebuild project cache on first run. When running a Julia command in the CLI for the first time, it may take a while to precompile the packages and build the project cache, so you won't see the results of running the command for a while.
 - **Typical First Run**: May take 15-30 seconds for precompilation before tests actually start
-- **Example Expected Output**: `Precompiling DrWatson... 3 dependencies successfully precompiled in 17 seconds`
+- **Example Expected Output**: `Precompiling Math_Foundations... 3 dependencies successfully precompiled in 17 seconds`
 - **Subsequent Runs**: Much faster once cache is built
 - **Don't Cancel Early**: Allow time for compilation phase to complete
 - **IMPORTANT**: This applies to ALL Julia commands including CI testing with `CI=true julia --project=. test/runtests.jl`

--- a/.github/instructions/notebooks.instructions.md
+++ b/.github/instructions/notebooks.instructions.md
@@ -3,15 +3,54 @@ applyTo: 'notebooks/**'
 ---
 # Notebook Conventions
 
-## Setup Pattern
+## Notebook Environment
 
-All notebooks should start with the standard DrWatson activation:
+Notebooks use a dedicated environment at `notebooks/` that is a superset of the root project.
+It includes the full Makie stack (GLMakie, WGLMakie, Bonito, Meshes, ImageShow) on top of all
+root dependencies. It is separate from the root, `test/`, and `docs/` environments.
+
+### Setup Pattern
+
+All notebooks should start with:
 
 ```julia
+# Set up Revise.jl for automatic code reloading
+# This only needs to be run once at the beginning of your notebook session
 using Revise
-using DrWatson
-quickactivate(@__DIR__, "Math_Foundations")
+
+# Load the package
 using Math_Foundations
+```
+
+`Revise` and `DrWatson` are loaded automatically via `~/.julia/config/startup.jl` on the
+developer's machine when running Julia interactively, but notebooks must not depend on this
+— it is machine-specific and will not work for anyone who clones the repo without that file.
+The Jupyter kernel runs in a separate process that does not share the REPL's loaded modules,
+so `using Revise` must be called explicitly in the setup cell even though startup.jl loaded
+it in the REPL.
+
+### Running the Notebooks Environment (REPL)
+
+To start Julia with the notebooks environment active from the repo root:
+
+```bash
+julia --project=./notebooks
+```
+
+`startup.jl` detects the explicit `--project` flag and skips its `quickactivate(".")` call, so
+the notebooks environment is preserved correctly. Alternatively, `cd` into `notebooks/` first
+and run `julia` normally — `quickactivate(".")` will find `notebooks/Project.toml` directly.
+
+### Adding Packages to the Notebooks Environment
+
+```bash
+julia --project=./notebooks -e 'using Pkg; Pkg.add("PackageName")'
+```
+
+Or interactively in the notebooks REPL:
+
+```julia
+] add PackageName
 ```
 
 ## Notebook Guidelines
@@ -27,3 +66,49 @@ using Math_Foundations
 - Plots render inline in Jupyter notebooks
 - No need for headless mode configuration
 - Use the same plotting functions from the package (`plot_parabola_roots_quadratic`, `plot_hyperbola`, etc.)
+
+## Julia Kernel Gotchas
+
+### Stale variable slot after a failed assignment
+
+If a cell fails mid-execution with an assignment like `foo = some_expr_using_foo`, Julia may
+register a declared-but-unassigned global slot for `foo` in `Main`. This slot **persists across
+cell re-runs** and shadows any same-named binding from imported modules (e.g., `LinearAlgebra.I`).
+Typical symptom: `UndefVarError: foo not defined` even though `foo` is clearly exported by the
+package, sometimes accompanied by "Also exported by ..." in the hint.
+
+**Fix: restart the Julia kernel.** Reloading the package (`using Math_Foundations` again) is not
+enough — the stale slot in `Main` survives until the kernel is fully restarted. After restarting,
+re-run the setup cell before re-running the failing cell.
+
+### Building a matrix from row vectors
+
+`[v1; v2; v3]` where all three are 1D vectors concatenates them into one long 1D vector, **not**
+a matrix. To stack 1D vectors as matrix rows, transpose each one first:
+
+```julia
+matrix = [v1'; v2'; v3']   # ✅ 3×n matrix
+matrix = [v1; v2; v3]      # ❌ 3n-element vector
+```
+
+This comes up whenever building a matrix row-by-row after row operations (e.g. Gauss-Jordan elimination).
+
+### Stale cell state from mutated variables across cells
+
+Cells share the same kernel state. If a variable is mutated across multiple cells (e.g. a matrix
+being updated step-by-step), re-running a later cell without re-running the earlier ones first
+will use the already-mutated value — producing wrong results silently.
+
+**Fix: re-run all dependent cells from the top**, or at minimum from the cell that initialises
+the variable. When in doubt, restart the kernel and re-run all cells in order.
+
+### `startup.jl` runs, but `atreplinit` callbacks do not
+
+Julia always runs `~/.julia/config/startup.jl` at process startup — this applies to REPL, scripts,
+and Jupyter kernels alike. However, `atreplinit do repl ... end` blocks only fire when Julia
+initialises an interactive REPL object. IJulia never creates one; it sets up its own I/O event
+loop instead. As a result, any `using` statements inside an `atreplinit` block in `startup.jl`
+(such as `using Revise`) are silently skipped in the Jupyter kernel.
+
+**Consequence:** every package needed in a notebook must be loaded explicitly in the setup cell,
+even if `startup.jl` loads it for interactive REPL sessions.

--- a/notebooks/Basics.ipynb
+++ b/notebooks/Basics.ipynb
@@ -1,29 +1,24 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Elementary Calculations"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Set up Revise.jl for automatic code reloading\n",
     "# This only needs to be run once at the beginning of your notebook session\n",
     "using Revise\n",
-    "using DrWatson\n",
     "\n",
-    "# Activate the project\n",
-    "quickactivate(@__DIR__, \"Math_Foundations\")\n",
-    "\n",
-    "# Load the package \n",
-    "using Math_Foundations\n",
-    "\n"
+    "# Load the package\n",
+    "using Math_Foundations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Elementary Calculations"
    ]
   },
   {
@@ -615,24 +610,6 @@
    "metadata": {},
    "source": [
     "# Functions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set up Revise.jl for automatic code reloading\n",
-    "# This only needs to be run once at the beginning of your notebook session\n",
-    "using Revise\n",
-    "using DrWatson\n",
-    "\n",
-    "# Activate the project\n",
-    "quickactivate(@__DIR__, \"Math_Foundations\")\n",
-    "\n",
-    "# Load the package \n",
-    "using Math_Foundations"
    ]
   },
   {
@@ -2002,24 +1979,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set up Revise.jl for automatic code reloading\n",
-    "# This only needs to be run once at the beginning of your notebook session\n",
-    "using Revise\n",
-    "using DrWatson\n",
-    "\n",
-    "# Activate the project\n",
-    "quickactivate(@__DIR__, \"Math_Foundations\")\n",
-    "\n",
-    "# Load the package \n",
-    "using Math_Foundations"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2460,24 +2419,6 @@
    "metadata": {},
    "source": [
     "# Geometry & Trigonometry"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set up Revise.jl for automatic code reloading\n",
-    "# This only needs to be run once at the beginning of your notebook session\n",
-    "using Revise\n",
-    "using DrWatson\n",
-    "\n",
-    "# Activate the project\n",
-    "quickactivate(@__DIR__, \"Math_Foundations\")\n",
-    "\n",
-    "# Load the package \n",
-    "using Math_Foundations"
    ]
   },
   {
@@ -4213,7 +4154,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.12",
+   "display_name": "Julia 1.12.6",
    "language": "julia",
    "name": "julia-1.12"
   },
@@ -4221,7 +4162,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.12.3"
+   "version": "1.12.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updates Copilot instructions and notebook conventions to reflect the workspace restructure completed in Phases 1–3.

**Changes:**

`.github/copilot-instructions.md`
- Add Julia Workspace Layout section documenting the workspace table, Manifest gitignore policy, uuidgen usage, and Project.toml header convention
- Fix test command to `julia --project=. -e 'using Pkg; Pkg.test()'`
- Fix docs build command to `julia --project=docs docs/make.jl`
- Fix stale DrWatson precompile example

`.github/instructions/notebooks.instructions.md`
- Remove DrWatson/quickactivate setup pattern
- Add Notebook Environment section: superset env description, REPL startup with `--project=./notebooks`, package-adding instructions
- Add Julia Kernel Gotchas section: stale variable slots, matrix from row vectors, stale cell state

`notebooks/Basics.ipynb`: update kernel metadata to Julia 1.12.6

Closes FOU-33, FOU-35, FOU-36, FOU-39, FOU-41